### PR TITLE
Bump AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
else:
```
Execution failed for task ':app:mergeReleaseResources'.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.1-6503028-linux Daemon #1: Unexpected error during compile '/home/vagrant/build/foehnix.widget/app/src/main/res/drawable-xxhdpi/refresh.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.
```

ref: https://issuetracker.google.com/issues/184872412 This is an issue of AGP 4.1. Updating AGP to 4.2 or above should fix it.

Fixed (we'll see heh) directly in F-Droid: https://gitlab.com/fdroid/fdroiddata/-/commit/d099f67158de4467cb4994705a3205ee2662d95d